### PR TITLE
[FIX] chat.service 파일 이름이 겹쳐서 생긴 의존성 주입 버그 해결

### DIFF
--- a/src/v1/sockets/chat/chat.manager.ts
+++ b/src/v1/sockets/chat/chat.manager.ts
@@ -4,7 +4,7 @@ import { ResponseMessage } from './chat.schema.js';
 import { ChatRoomType } from '@prisma/client';
 import { checkBlockStatus } from './chat.client.js';
 
-export default class ChatService {
+export default class ChatManager {
   constructor() {}
 
   async createChatRoom(userAId: number, userBId: number) {

--- a/src/v1/sockets/chat/chat.namespace.ts
+++ b/src/v1/sockets/chat/chat.namespace.ts
@@ -1,11 +1,11 @@
 import { Namespace } from 'socket.io';
 import { socketMiddleware } from '../utils/middleware.js';
 import { handleConnection } from './connection.handler.js';
-import ChatService from './chat.service.js';
+import ChatManager from './chat.manager.js';
 
 export default async function chatNamespace(namespace: Namespace) {
   namespace.use(socketMiddleware);
 
-  const chatService = new ChatService();
-  namespace.on('connection', (socket) => handleConnection(socket, chatService));
+  const chatManager = new ChatManager();
+  namespace.on('connection', (socket) => handleConnection(socket, chatManager));
 }

--- a/src/v1/sockets/chat/connection.handler.ts
+++ b/src/v1/sockets/chat/connection.handler.ts
@@ -1,20 +1,20 @@
 import { Socket } from 'socket.io';
-import ChatService from './chat.service.js';
+import ChatManager from './chat.manager.js';
 import { requestMessageSchema, ResponseMessage, responseMessageSchema } from './chat.schema.js';
 import { dependencies } from './chat.dependencies.js';
 import { ForbiddenException } from '../../../v1/common/exceptions/core.error.js';
 import { checkBlockStatus } from './chat.client.js';
 import { ChatRoomType } from '@prisma/client';
 
-export async function handleConnection(socket: Socket, chatService: ChatService) {
+export async function handleConnection(socket: Socket, chatManager: ChatManager) {
   try {
     const userId = socket.data.userId;
     console.log(`🟢 [/chat] Connected: ${socket.id}, ${userId}`);
 
-    await chatService.joinPersonalRoom(socket, userId);
-    await chatService.joinChatRooms(socket, userId);
+    await chatManager.joinPersonalRoom(socket, userId);
+    await chatManager.joinChatRooms(socket, userId);
 
-    socket.on('message', (payload) => handleIncomingMessage({socket, chatService, userId, payload}));
+    socket.on('message', (payload) => handleIncomingMessage({socket, chatManager, userId, payload}));
 
     socket.on('disconnect', async () => {
       console.log(`🔴 [/status] Disconnected: ${socket.id}`);
@@ -26,12 +26,12 @@ export async function handleConnection(socket: Socket, chatService: ChatService)
 
 type HandleIncomingMessageParams = {
   socket: Socket;
-  chatService: ChatService;
+  chatManager: ChatManager;
   userId: number;
   payload: unknown;
 };
 
-async function handleIncomingMessage({socket, chatService, userId, payload}: HandleIncomingMessageParams) {
+async function handleIncomingMessage({socket, chatManager, userId, payload}: HandleIncomingMessageParams) {
   try {
     const { messageData, roomType, otherUserId } = await validateIncomingMessage(userId, payload);
 
@@ -42,7 +42,7 @@ async function handleIncomingMessage({socket, chatService, userId, payload}: Han
       if (isBlocked) return;
     }
 
-    await chatService.saveMessage(messageData);
+    await chatManager.saveMessage(messageData);
     // TODO: Kafka로 메시지 전송
 
   } catch (e) {


### PR DESCRIPTION
## 🔗 반영 브랜치

[bug/7-thischatserviceloadmessages-is-not-a-function-버그](https://github.com/42-Gang/chat-server/tree/bug/7-thischatserviceloadmessages-is-not-a-function-%EB%B2%84%EA%B7%B8) -> dev

## 📝 작업 내용

![image](https://github.com/user-attachments/assets/8d4dee75-88e4-4dd1-913c-43f493a87e47)

`**/src/**/*.service`로 diContainer에서 모듈을 불러오는데, socket 디렉토리와 api 디렉토리 내에 chat.service라는 동일한 이름의 파일이 존재해서 발생한 버그 해결

sockets 디렉토리 내의 chat.service -> chat.manager로 이름 변경
