### PR TITLE
[FIX] 20 채팅방 아이디 조회 api 수정

### DIFF
--- a/src/v1/apis/chat.service.ts
+++ b/src/v1/apis/chat.service.ts
@@ -7,6 +7,7 @@ import { STATUS } from '../common/constants/status.js';
 import { NotFoundException, UnAuthorizedException } from '../common/exceptions/core.error.js';
 import { TypeOf } from 'zod';
 import { getDmRoomIdQuerySchema } from './schemas/get-room-id.schema.js';
+import { getUserNick } from '../sockets/chat/chat.client.js';
 
 export default class ChatService {
   constructor(
@@ -15,10 +16,11 @@ export default class ChatService {
     private readonly chatRoomRepository: ChatRoomRepositoryInterface,
   ) {}
 
-  private messagesToResponse(messages: ChatMessage) {
+  private async messagesToResponse(messages: ChatMessage) {
+    const nickname = await getUserNick(messages.userId);
     return {
       id: messages.id,
-      nickname: 'test',
+      nickname: nickname,
       timestamp: new Date(messages.timestamp),
       message: messages.contents,
     };

--- a/src/v1/apis/chat.service.ts
+++ b/src/v1/apis/chat.service.ts
@@ -40,7 +40,8 @@ export default class ChatService {
       throw new NotFoundException('채팅 메시지가 존재하지 않습니다.');
     }
 
-    const response = messages.map((item) => this.messagesToResponse(item));
+    const response = await Promise.all(messages.map((item) => this.messagesToResponse(item)));
+
     return {
       status: STATUS.SUCCESS,
       data: {

--- a/src/v1/apis/schemas/chat.schema.ts
+++ b/src/v1/apis/schemas/chat.schema.ts
@@ -2,9 +2,9 @@ import { z } from 'zod';
 
 export const chatMessageSchema = z.object({
   id: z.preprocess((val) => Number(val), z.number()),
-  nickname: z.string().min(2).max(8),
+  nickname: z.string(),
   timestamp: z.date(),
-  message: z.string().min(1).max(200),
+  message: z.string(),
 });
 
 //채팅룸의 모든 메세지 로드 (GET)

--- a/src/v1/apis/schemas/chat.schema.ts
+++ b/src/v1/apis/schemas/chat.schema.ts
@@ -4,9 +4,5 @@ export const chatMessageSchema = z.object({
   id: z.preprocess((val) => Number(val), z.number()),
   nickname: z.string(),
   timestamp: z.date(),
-  message: z.string(),
+  message: z.string().min(1).max(200),
 });
-
-//채팅룸의 모든 메세지 로드 (GET)
-//내가 속한 모든 채팅룸 리스트 로드 (GET)
-//채팅룸에 속한 유저 리스트 로드 (GET)


### PR DESCRIPTION
## 🔗 반영 브랜치

fix/20-채팅방-아이디-조회-api-수정 -> dev

## 📝 작업 내용

원인 : fastify에서 응답 스키마로 promise를 받지 않는데, 닉네임을 받아오기 위해 gotClient를 사용한 부분에서 promise객체를 포함하고 있어서 에러 발생 
해결 : 응답을 promise.all로 감싸서, 모든 비동기 처리가 끝난 후 응답을 하도록 수정
