### PR TITLE
[FIX] 채팅 메시지 로딩 시 N+1 문제 해결

### DIFF
--- a/src/v1/apis/chat.service.ts
+++ b/src/v1/apis/chat.service.ts
@@ -1,5 +1,3 @@
-import ChatRoomRepositoryInterface from '../storage/database/interfaces/chatRoom.repository.interface.js';
-import ChatJoinListRepositoryInterface from '../storage/database/prisma/chatJoinList.repository.js';
 import ChatMessageRepositoryInterface from '../storage/database/prisma/chatMessage.repository.js';
 
 import { STATUS } from '../common/constants/status.js';
@@ -8,20 +6,20 @@ import { TypeOf } from 'zod';
 import { getDmRoomIdQuerySchema } from './schemas/get-room-id.schema.js';
 import { getUserNick } from '../sockets/chat/chat.client.js';
 import { FastifyBaseLogger } from 'fastify';
+import ChatRoomRepositoryPrisma from '../storage/database/prisma/chatRoom.repository.js';
 
 export default class ChatService {
   constructor(
-    private readonly chatJoinListRepository: ChatJoinListRepositoryInterface,
     private readonly chatMessageRepository: ChatMessageRepositoryInterface,
-    private readonly chatRoomRepository: ChatRoomRepositoryInterface,
+    private readonly chatRoomRepository: ChatRoomRepositoryPrisma,
     private readonly logger: FastifyBaseLogger,
   ) {}
 
   async loadMessages(roomId: number, userId: number | undefined) {
-    const room = await this.chatRoomRepository.findById(roomId);
-    if (!room) throw new NotFoundException('채팅방이 존재하지 않습니다.');
+    const roomWithMembers = await this.chatRoomRepository.findByIdJoinMembers(roomId);
+    if (!roomWithMembers) throw new NotFoundException('채팅방이 존재하지 않습니다.');
 
-    const chatJoinList = await this.chatJoinListRepository.findManyByRoomId(roomId);
+    const chatJoinList = roomWithMembers.members;
     if (!chatJoinList || !chatJoinList.some((user) => user.userId === userId)) {
       throw new UnAuthorizedException('사용자가 포함된 채팅방이 아닙니다.');
     }

--- a/src/v1/apis/chat.service.ts
+++ b/src/v1/apis/chat.service.ts
@@ -17,16 +17,6 @@ export default class ChatService {
     private readonly logger: FastifyBaseLogger,
   ) {}
 
-  // private async messagesToResponse(messages: ChatMessage) {
-  //   const nickname = await getUserNick(messages.userId);
-  //   return {
-  //     id: messages.id,
-  //     nickname: nickname,
-  //     timestamp: new Date(messages.timestamp),
-  //     message: messages.contents,
-  //   };
-  // }
-
   async loadMessages(roomId: number, userId: number | undefined) {
     const room = await this.chatRoomRepository.findById(roomId);
     if (!room) throw new NotFoundException('채팅방이 존재하지 않습니다.');

--- a/src/v1/apis/chat.service.ts
+++ b/src/v1/apis/chat.service.ts
@@ -2,36 +2,37 @@ import ChatRoomRepositoryInterface from '../storage/database/interfaces/chatRoom
 import ChatJoinListRepositoryInterface from '../storage/database/prisma/chatJoinList.repository.js';
 import ChatMessageRepositoryInterface from '../storage/database/prisma/chatMessage.repository.js';
 
-import { ChatMessage } from '@prisma/client';
 import { STATUS } from '../common/constants/status.js';
 import { NotFoundException, UnAuthorizedException } from '../common/exceptions/core.error.js';
 import { TypeOf } from 'zod';
 import { getDmRoomIdQuerySchema } from './schemas/get-room-id.schema.js';
 import { getUserNick } from '../sockets/chat/chat.client.js';
+import { FastifyBaseLogger } from 'fastify';
 
 export default class ChatService {
   constructor(
     private readonly chatJoinListRepository: ChatJoinListRepositoryInterface,
     private readonly chatMessageRepository: ChatMessageRepositoryInterface,
     private readonly chatRoomRepository: ChatRoomRepositoryInterface,
+    private readonly logger: FastifyBaseLogger,
   ) {}
 
-  private async messagesToResponse(messages: ChatMessage) {
-    const nickname = await getUserNick(messages.userId);
-    return {
-      id: messages.id,
-      nickname: nickname,
-      timestamp: new Date(messages.timestamp),
-      message: messages.contents,
-    };
-  }
+  // private async messagesToResponse(messages: ChatMessage) {
+  //   const nickname = await getUserNick(messages.userId);
+  //   return {
+  //     id: messages.id,
+  //     nickname: nickname,
+  //     timestamp: new Date(messages.timestamp),
+  //     message: messages.contents,
+  //   };
+  // }
 
   async loadMessages(roomId: number, userId: number | undefined) {
-    const rooms = await this.chatRoomRepository.findById(roomId);
-    if (!rooms) throw new NotFoundException('채팅방이 존재하지 않습니다.');
+    const room = await this.chatRoomRepository.findById(roomId);
+    if (!room) throw new NotFoundException('채팅방이 존재하지 않습니다.');
 
-    const members = await this.chatJoinListRepository.findManyByRoomId(roomId);
-    if (!members || !members.some((user) => user.userId === userId)) {
+    const chatJoinList = await this.chatJoinListRepository.findManyByRoomId(roomId);
+    if (!chatJoinList || !chatJoinList.some((user) => user.userId === userId)) {
       throw new UnAuthorizedException('사용자가 포함된 채팅방이 아닙니다.');
     }
 
@@ -40,7 +41,27 @@ export default class ChatService {
       throw new NotFoundException('채팅 메시지가 존재하지 않습니다.');
     }
 
-    const response = await Promise.all(messages.map((item) => this.messagesToResponse(item)));
+    const members: Record<number, string> = Object.fromEntries(
+      await Promise.all(
+        chatJoinList.map(async (item): Promise<[number, string]> => {
+          const nickname = await getUserNick(item.userId);
+          if (!nickname) {
+            this.logger.error(`Failed to fetch nickname for userId: ${item.userId}`);
+            return [item.userId, 'unknown'];
+          }
+          return [item.userId, nickname];
+        }),
+      ),
+    );
+
+    const response = messages.map((message) => {
+      return {
+        id: message.id,
+        nickname: members[message.userId],
+        timestamp: new Date(message.timestamp),
+        message: message.contents,
+      };
+    });
 
     return {
       status: STATUS.SUCCESS,

--- a/src/v1/storage/database/prisma/chatRoom.repository.ts
+++ b/src/v1/storage/database/prisma/chatRoom.repository.ts
@@ -32,6 +32,12 @@ export default class ChatRoomRepositoryPrisma implements ChatRoomRepositoryInter
     return room.type;
   }
 
+  findByIdJoinMembers(id: number): Promise<Prisma.ChatRoomGetPayload<{
+    include: { members: true };
+  }> | null> {
+    return this.prisma.chatRoom.findUnique({ where: { id }, include: { members: true } });
+  }
+
   //TODO: privateRoomId로 변경 (id 반환하니까)
   async getPrivateRoomByUserIds(userAId: number, userBId: number): Promise<number | null> {
     const room = await this.prisma.chatRoom.findFirst({


### PR DESCRIPTION
## 📝 작업 내용

- 채팅 메시지 불러오기(loadMessages) 과정에서 발생하던 N+1 쿼리 문제 해결
  - 기존: 각 메시지마다 개별적으로 사용자 닉네임 조회 (user-service로의 api 요청)
  - 변경: 모든 참여자 닉네임을 한 번에 가져와 Dict(Record) 형태로 캐싱 후 매핑
- 닉네임 조회 실패 시 로깅 추가 (unknown 으로 fallback) -> logging
- ChatRoomRepository에 `findByIdJoinMembers` 메서드 추가
  - 채팅방과 멤버를 함께 조회할 수 있도록 하여 join 기반 접근 가능
- `messagesToResponse` 메서드 제거 → Promise.all + Object.fromEntries 활용한 변환 로직으로 대체


### 📸 스크린샷 (선택)

**기존 약 1.7초 소요.**
<img width="2048" height="1257" alt="image" src="https://github.com/user-attachments/assets/910e9df7-032b-4815-9670-a5898045826f" />

**Timeout 기준을 300ms -> 1500ms로 변경 (400ms 소요)**
<img width="2048" height="864" alt="image" src="https://github.com/user-attachments/assets/955a0e3f-c5ac-4134-aeb6-b514b0a8af07" />

**N + 1 문제 해결 (22ms 소요)**
<img width="1920" height="1002" alt="image" src="https://github.com/user-attachments/assets/5ef7bf69-41e9-49df-9851-94c9e0fd4825" />
