### PR TITLE
[FEAT] Loki를 위한 로깅 개선 (+ OPTL trace_id 주입)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN corepack enable \
  && corepack prepare pnpm@latest --activate
 
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --prod --frozen-lockfile
+COPY --from=builder /app/node_modules ./node_modules
+RUN pnpm prune --prod
 
 # 빌드 결과와 Prisma Client 복사
 COPY --from=builder /app/dist ./dist

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,7 +13,7 @@ export default async function app(fastify: FastifyInstance) {
 
 function setErrorHandler(fastify: FastifyInstance) {
   fastify.setErrorHandler((error: FastifyError, request: FastifyRequest, reply: FastifyReply) => {
-    fastify.log.error(error);
+    fastify.log.error({ err: error, route: request.url, method: request.method }, 'request error');
     const statusCode: number = error.statusCode || 500;
     reply.code(statusCode).send({
       status: STATUS.ERROR,
@@ -54,7 +54,6 @@ function setMiddleware(fastify: FastifyInstance) {
 
 function setDecorate(fastify: FastifyInstance) {
   fastify.decorate('authenticate', async (request: FastifyRequest, reply: FastifyReply) => {
-    console.log(request.authenticated);
     if (!request.authenticated) {
       reply.code(401).send({
         status: STATUS.ERROR,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,13 @@
 import { createServer, startServer } from './server-utils.js';
 import { configureServer, registerPlugins, setupGracefulShutdown } from './server-config.js';
 import { createSocketServer } from './plugins/socket.js';
+import { setLogger } from './plugins/logger.js';
+import { Logger } from 'pino';
 
 async function init() {
   const server = createServer();
+  setLogger(server.log as Logger);
+
   await configureServer(server); // 서버 설정
   await registerPlugins(server); // 플러그인 등록
 

--- a/src/plugins/logger.ts
+++ b/src/plugins/logger.ts
@@ -1,0 +1,118 @@
+import { pino, LoggerOptions, Logger } from 'pino';
+import { context, trace } from '@opentelemetry/api';
+
+let logger: Logger = pino({ level: process.env.LOG_LEVEL || 'info' });
+
+export function setLogger(newLogger: Logger) {
+  // Fastify의 logger는 Pino 호환이므로 Logger로 사용
+  logger = newLogger;
+}
+
+export function getLogger() {
+  return logger;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getString(obj: Record<string, unknown>, key: string): string | undefined {
+  const v = obj[key];
+  return typeof v === 'string' ? v : undefined;
+}
+
+function getNumber(obj: Record<string, unknown>, key: string): number | undefined {
+  const v = obj[key];
+  return typeof v === 'number' ? v : undefined;
+}
+
+function getObject(obj: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
+  const v = obj[key];
+  return isObject(v) ? v : undefined;
+}
+
+function getTraceContextFields(): Record<string, unknown> {
+  const span = trace.getSpan(context.active());
+  if (!span) return {};
+  const sc = span.spanContext();
+  return {
+    trace_id: sc.traceId,
+    span_id: sc.spanId,
+    trace_flags: sc.traceFlags,
+  };
+}
+
+export function getPinoOptions(): LoggerOptions {
+  const errSerializer = (error: unknown) => {
+    const o = isObject(error) ? error : {};
+    const name = getString(o, 'name') || 'Error';
+    const message = getString(o, 'message') || String(error);
+    const code = getString(o, 'code');
+
+    const response = getObject(o, 'response');
+    const statusCode =
+      (response && getNumber(response, 'statusCode')) ?? getNumber(o, 'statusCode');
+
+    const options = getObject(o, 'options');
+    const method = options ? getString(options, 'method') : undefined;
+    const urlRaw = options ? (options['url'] as unknown) : undefined;
+    const request = getObject(o, 'request');
+    const requestUrl = request ? getString(request, 'requestUrl') : undefined;
+
+    // Detect got HTTPError-like
+    const isGotHttpError =
+      name === 'HTTPError' || code === 'ERR_NON_2XX_3XX_RESPONSE' || !!response;
+
+    const stackRaw = getString(o, 'stack');
+    const stack = stackRaw ? stackRaw : undefined;
+
+    const base: Record<string, unknown> = { name, message };
+    if (code) base.code = code;
+    if (typeof statusCode === 'number') base.statusCode = statusCode;
+    if (stack) base.stack = stack;
+
+    if (isGotHttpError) {
+      let url: string | undefined;
+      if (typeof urlRaw === 'string') url = urlRaw;
+      else if (
+        isObject(urlRaw) &&
+        typeof (urlRaw as { toString?: () => string }).toString === 'function'
+      ) {
+        try {
+          url = (urlRaw as { toString: () => string }).toString();
+        } catch {
+          url = requestUrl;
+        }
+      } else {
+        url = requestUrl;
+      }
+
+      base.http = {
+        method,
+        url,
+      };
+    }
+
+    return base;
+  };
+
+  return {
+    level: process.env.LOG_LEVEL || 'info',
+    redact: {
+      paths: ['req.headers.authorization', 'req.headers.cookie', '*.password', '*.token'],
+      censor: '[Redacted]',
+    },
+    formatters: {
+      level(label: string) {
+        return { level: label };
+      },
+    },
+    mixin() {
+      // 각 로그 호출 시 활성 스팬 컨텍스트를 주입
+      return getTraceContextFields();
+    },
+    serializers: {
+      err: errSerializer,
+    },
+  } as LoggerOptions;
+}

--- a/src/plugins/logger.ts
+++ b/src/plugins/logger.ts
@@ -42,60 +42,59 @@ function getTraceContextFields(): Record<string, unknown> {
   };
 }
 
-export function getPinoOptions(): LoggerOptions {
-  const errSerializer = (error: unknown) => {
-    const o = isObject(error) ? error : {};
-    const name = getString(o, 'name') || 'Error';
-    const message = getString(o, 'message') || String(error);
-    const code = getString(o, 'code');
+const errSerializer = (rowError: unknown) => {
+  const error = isObject(rowError) ? rowError : {};
+  const name = getString(error, 'name') || 'Error';
+  const message = getString(error, 'message') || String(rowError);
+  const code = getString(error, 'code');
 
-    const response = getObject(o, 'response');
-    const statusCode =
-      (response && getNumber(response, 'statusCode')) ?? getNumber(o, 'statusCode');
+  const response = getObject(error, 'response');
+  const statusCode =
+    (response && getNumber(response, 'statusCode')) ?? getNumber(error, 'statusCode');
 
-    const options = getObject(o, 'options');
-    const method = options ? getString(options, 'method') : undefined;
-    const urlRaw = options ? (options['url'] as unknown) : undefined;
-    const request = getObject(o, 'request');
-    const requestUrl = request ? getString(request, 'requestUrl') : undefined;
+  const options = getObject(error, 'options');
+  const method = options ? getString(options, 'method') : undefined;
+  const urlRaw = options ? (options['url'] as unknown) : undefined;
+  const request = getObject(error, 'request');
+  const requestUrl = request ? getString(request, 'requestUrl') : undefined;
 
-    // Detect got HTTPError-like
-    const isGotHttpError =
-      name === 'HTTPError' || code === 'ERR_NON_2XX_3XX_RESPONSE' || !!response;
+  // Detect got HTTPError-like
+  const isGotHttpError = name === 'HTTPError' || code === 'ERR_NON_2XX_3XX_RESPONSE' || !!response;
 
-    const stackRaw = getString(o, 'stack');
-    const stack = stackRaw ? stackRaw : undefined;
+  const stackRaw = getString(error, 'stack');
+  const stack = stackRaw ? stackRaw : undefined;
 
-    const base: Record<string, unknown> = { name, message };
-    if (code) base.code = code;
-    if (typeof statusCode === 'number') base.statusCode = statusCode;
-    if (stack) base.stack = stack;
+  const base: Record<string, unknown> = { name, message };
+  if (code) base.code = code;
+  if (typeof statusCode === 'number') base.statusCode = statusCode;
+  if (stack) base.stack = stack;
 
-    if (isGotHttpError) {
-      let url: string | undefined;
-      if (typeof urlRaw === 'string') url = urlRaw;
-      else if (
-        isObject(urlRaw) &&
-        typeof (urlRaw as { toString?: () => string }).toString === 'function'
-      ) {
-        try {
-          url = (urlRaw as { toString: () => string }).toString();
-        } catch {
-          url = requestUrl;
-        }
-      } else {
+  if (isGotHttpError) {
+    let url: string | undefined;
+    if (typeof urlRaw === 'string') url = urlRaw;
+    else if (
+      isObject(urlRaw) &&
+      typeof (urlRaw as { toString?: () => string }).toString === 'function'
+    ) {
+      try {
+        url = (urlRaw as { toString: () => string }).toString();
+      } catch {
         url = requestUrl;
       }
-
-      base.http = {
-        method,
-        url,
-      };
+    } else {
+      url = requestUrl;
     }
 
-    return base;
-  };
+    base.http = {
+      method,
+      url,
+    };
+  }
 
+  return base;
+};
+
+export function getPinoOptions(): LoggerOptions {
   return {
     level: process.env.LOG_LEVEL || 'info',
     redact: {

--- a/src/server-utils.ts
+++ b/src/server-utils.ts
@@ -1,4 +1,5 @@
 import Fastify, { FastifyInstance } from 'fastify';
+import { getPinoOptions } from './plugins/logger.js';
 
 export function createServer() {
   return Fastify({
@@ -15,7 +16,7 @@ export function createServer() {
 export function getLoggerOptions() {
   if (process.env.NODE_ENV === 'dev') {
     return {
-      level: 'debug',
+      ...getPinoOptions(),
       transport: {
         target: 'pino-pretty',
         options: {
@@ -25,7 +26,9 @@ export function getLoggerOptions() {
       },
     };
   }
-  return { level: process.env.LOG_LEVEL || 'info' };
+  return {
+    ...getPinoOptions(),
+  };
 }
 
 export async function startServer(server: FastifyInstance) {

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -3,11 +3,12 @@ import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentation
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { PrismaInstrumentation } from '@prisma/instrumentation';
 import { Span } from '@opentelemetry/api';
+import { getLogger } from './plugins/logger.js';
 
 if (!process.env.JAEGER_ENDPOINT) {
   throw new Error('JAEGER_ENDPOINT environment variable is not set');
 }
-console.log(`Using Jaeger endpoint: ${process.env.JAEGER_ENDPOINT}`);
+getLogger().info({ jaeger: process.env.JAEGER_ENDPOINT }, 'Using Jaeger endpoint');
 
 interface KafkajsMessage {
   key?: Buffer | string | null;

--- a/src/v1/sockets/chat/chat.client.ts
+++ b/src/v1/sockets/chat/chat.client.ts
@@ -1,4 +1,5 @@
 import { gotClient } from '../../../plugins/http.client.js';
+import { getLogger } from '../../../plugins/logger.js';
 
 export async function checkBlockStatus(userAId: number, userBId: number): Promise<boolean> {
   try {
@@ -15,9 +16,7 @@ export async function checkBlockStatus(userAId: number, userBId: number): Promis
     if (friendStatus.body.data.status === 'BLOCKED') return true;
     return false;
   } catch (e) {
-    console.error('Error checking block status:', e);
-    console.error('User A ID:', userAId);
-    console.error('User B ID:', userBId);
+    getLogger().warn({ err: e, userAId, userBId }, 'checkBlockStatus failed');
     return false;
   }
 }
@@ -39,8 +38,7 @@ export async function getUserNick(userId: number): Promise<string | undefined> {
     });
     return friendStatus.body.data.nickname;
   } catch (e) {
-    console.error('Error getting user nickname', e);
-    console.error('User ID:', userId);
+    getLogger().warn({ err: e, userId }, 'getUserNick failed');
     return undefined;
   }
 }

--- a/src/v1/sockets/chat/chat.manager.ts
+++ b/src/v1/sockets/chat/chat.manager.ts
@@ -3,6 +3,7 @@ import { dependencies } from './chat.dependencies.js';
 import { RequestMessage } from './chat.schema.js';
 import { ChatRoom, ChatRoomType } from '@prisma/client';
 import { checkBlockStatus } from './chat.client.js';
+import { getLogger } from '../../../plugins/logger.js';
 
 export default class ChatManager {
   constructor() {}
@@ -34,7 +35,7 @@ export default class ChatManager {
   async joinChatRooms(socket: Socket, userId: number) {
     const chatRooms = await dependencies.chatJoinListRepository.findManyByUserId(userId);
     if (!chatRooms || chatRooms.length === 0) {
-      console.log(`No chat rooms found for user ${userId}`);
+      getLogger().debug({ userId }, 'No chat rooms found for user');
       return;
     }
     await Promise.all(
@@ -80,7 +81,7 @@ export default class ChatManager {
     const roomId = await dependencies.chatRoomRepository.getPrivateRoomByUserIds(userAId, userBId);
 
     userSocketA?.socketsLeave(`room:${roomId}`);
-    console.log(`🟡 ${userAId} left room:${roomId}`);
+    getLogger().info({ userId: userAId, roomId }, 'left room');
   }
 
   async joinDirectMessageRoom(namespace: Namespace, userAId: number, userBId: number) {
@@ -88,7 +89,7 @@ export default class ChatManager {
     const roomId = await dependencies.chatRoomRepository.getPrivateRoomByUserIds(userAId, userBId);
 
     userSocketA?.socketsJoin(`room:${roomId}`);
-    console.log(`🟡 ${userAId} join room:${roomId}`);
+    getLogger().info({ userId: userAId, roomId }, 'join room');
   }
 
   async addParticipantsToRoom(namespace: Namespace, roomId: number, ...userIds: number[]) {

--- a/src/v1/sockets/chat/chat.manager.ts
+++ b/src/v1/sockets/chat/chat.manager.ts
@@ -10,7 +10,7 @@ export default class ChatManager {
 
   //TODO: repository 안에 넣을 수 있는 함수
   async createChatRoom(userAId: number, userBId: number): Promise<ChatRoom> {
-    const room = await dependencies.chatRoomRepository.create({
+    return dependencies.chatRoomRepository.create({
       type: 'PRIVATE',
       members: {
         create: [
@@ -23,8 +23,6 @@ export default class ChatManager {
         ],
       },
     });
-
-    return room;
   }
 
   //TODO: 'user:${userId}' 상수화
@@ -60,20 +58,17 @@ export default class ChatManager {
     if (!otherUser) throw new Error('1:1 채팅방에 다른 유저가 존재하지 않습니다');
 
     const isBlocked = await checkBlockStatus(userId, otherUser.userId);
-    if (isBlocked) return false;
-    return true;
+    return !isBlocked;
   }
 
   //TODO: 바로 return
   async saveMessage(userId: number, payload: RequestMessage) {
-    const message = await dependencies.chatMessageRepository.create({
+    return dependencies.chatMessageRepository.create({
       roomId: payload.roomId,
       userId: userId,
       contents: payload.contents,
       timestamp: new Date(),
     });
-
-    return message;
   }
 
   async leaveDirectMessageRoom(namespace: Namespace, userAId: number, userBId: number) {

--- a/src/v1/sockets/chat/connection.handler.ts
+++ b/src/v1/sockets/chat/connection.handler.ts
@@ -13,6 +13,8 @@ import { sendChat } from './kafka/producer.js';
 import { getLogger } from '../../../plugins/logger.js';
 import { trace } from '@opentelemetry/api';
 
+const TRACER_NAME = 'chat-service';
+
 export async function handleConnection(
   socket: Socket,
   chatManager: ChatManager,
@@ -22,7 +24,7 @@ export async function handleConnection(
     const userId = socket.data.userId;
     getLogger().info({ sid: socket.id, userId }, '[/chat] connected');
 
-    const tracer = trace.getTracer('chat-service');
+    const tracer = trace.getTracer(TRACER_NAME);
     await tracer.startActiveSpan('socket.connection', async (span) => {
       try {
         await chatManager.joinPersonalRoom(socket, userId);
@@ -33,7 +35,7 @@ export async function handleConnection(
     });
 
     socket.on('message', async (payload) => {
-      const tracer = trace.getTracer('chat-service');
+      const tracer = trace.getTracer(TRACER_NAME);
       await tracer.startActiveSpan('socket.message', async (span) => {
         try {
           await handleIncomingMessage({ socket, chatManager, userId, payload, namespace });

--- a/src/v1/sockets/chat/connection.handler.ts
+++ b/src/v1/sockets/chat/connection.handler.ts
@@ -6,10 +6,12 @@ import {
   BadRequestException,
   ForbiddenException,
   NotFoundException,
-} from '../../../v1/common/exceptions/core.error.js';
+} from '../../common/exceptions/core.error.js';
 import { checkBlockStatus, getUserNick } from './chat.client.js';
 import { ChatRoomType } from '@prisma/client';
 import { sendChat } from './kafka/producer.js';
+import { getLogger } from '../../../plugins/logger.js';
+import { trace } from '@opentelemetry/api';
 
 export async function handleConnection(
   socket: Socket,
@@ -18,26 +20,36 @@ export async function handleConnection(
 ) {
   try {
     const userId = socket.data.userId;
-    console.log(`🟢 [/chat] Connected: ${socket.id}, ${userId}`);
+    getLogger().info({ sid: socket.id, userId }, '[/chat] connected');
 
-    await chatManager.joinPersonalRoom(socket, userId);
-    await chatManager.joinChatRooms(socket, userId);
+    const tracer = trace.getTracer('chat-service');
+    await tracer.startActiveSpan('socket.connection', async (span) => {
+      try {
+        await chatManager.joinPersonalRoom(socket, userId);
+        await chatManager.joinChatRooms(socket, userId);
+      } finally {
+        span.end();
+      }
+    });
 
-    socket.on('message', (payload) =>
-      handleIncomingMessage({
-        socket,
-        chatManager,
-        userId,
-        payload,
-        namespace,
-      }),
-    );
+    socket.on('message', (payload) => {
+      const tracer = trace.getTracer('chat-service');
+      void tracer.startActiveSpan('socket.message', async (span) => {
+        try {
+          await handleIncomingMessage({ socket, chatManager, userId, payload, namespace });
+        } catch (err) {
+          getLogger().error({ err, sid: socket.id }, 'message handler error');
+        } finally {
+          span.end();
+        }
+      });
+    });
 
     socket.on('disconnect', async () => {
-      console.log(`🔴 [/chat] Disconnected: ${socket.id}`);
+      getLogger().info({ sid: socket.id }, '[/chat] disconnected');
     });
   } catch (error) {
-    console.error(`Error in connection handler: ${error}`);
+    getLogger().error({ err: error, sid: socket.id }, 'connection handler error');
   }
 }
 
@@ -67,16 +79,14 @@ async function handleIncomingMessage({
     }
 
     const messageData = await chatManager.saveMessage(userId, payload);
-    console.log('메시지 저장 완료:', messageData);
+    getLogger().info({ messageId: messageData.id, roomId: messageData.roomId }, 'message saved');
 
-    //여기서부터
     const nickname = await getUserNick(userId);
     if (!nickname) {
       throw new NotFoundException('사용자 정보를 찾을 수 없습니다');
     }
 
     const messageToSend = responseMessageSchema.parse({
-      //타입형으로 뺏으니까 아래와 같이 묶어소 함수고
       roomId: messageData.roomId,
       userId: messageData.userId,
       messageId: messageData.id,
@@ -88,9 +98,12 @@ async function handleIncomingMessage({
     namespace.to(`room:${messageToSend.roomId}`).emit('message', messageToSend);
 
     await sendChat(messageToSend);
-    console.log('✅ Kafka 이벤트 전송 완료:', messageToSend);
+    getLogger().info(
+      { roomId: messageToSend.roomId, messageId: messageToSend.messageId },
+      'kafka event sent',
+    );
   } catch (e) {
-    console.error('❌ 메시지 처리 실패:', e);
+    getLogger().error({ err: e, sid: socket.id }, 'message handling failed');
     socket.emit('error', { error: '메시지 보내기 실패' });
   }
 }

--- a/src/v1/sockets/chat/connection.handler.ts
+++ b/src/v1/sockets/chat/connection.handler.ts
@@ -32,9 +32,9 @@ export async function handleConnection(
       }
     });
 
-    socket.on('message', (payload) => {
+    socket.on('message', async (payload) => {
       const tracer = trace.getTracer('chat-service');
-      void tracer.startActiveSpan('socket.message', async (span) => {
+      await tracer.startActiveSpan('socket.message', async (span) => {
         try {
           await handleIncomingMessage({ socket, chatManager, userId, payload, namespace });
         } catch (err) {

--- a/src/v1/sockets/chat/kafka/consumer.ts
+++ b/src/v1/sockets/chat/kafka/consumer.ts
@@ -8,6 +8,7 @@ import {
   handleUserLogout,
 } from './consumer.handler.js';
 import ChatManager from '../chat.manager.js';
+import { getLogger } from '../../../../plugins/logger.js';
 
 const consumer = kafka.consumer({ groupId: GROUP_IDS.FRIEND, sessionTimeout: 10000 });
 
@@ -19,12 +20,13 @@ export async function startConsumer(namespace: Namespace, chatManager: ChatManag
   await consumer.run({
     eachMessage: async ({ topic, message }) => {
       if (!message.value) {
-        return console.warn(`Null message value for topic ${topic}`);
+        getLogger().warn({ topic }, 'Null message value');
+        return;
       }
 
       try {
         const parsedMessage = JSON.parse(message.value.toString());
-        console.log('parsedMessage', parsedMessage);
+        getLogger().debug({ topic, message: parsedMessage }, 'Kafka message received');
 
         if (parsedMessage.eventType === FRIEND_EVENTS.ADDED) {
           await handleFriendAddEvent(parsedMessage, namespace, chatManager);
@@ -43,11 +45,9 @@ export async function startConsumer(namespace: Namespace, chatManager: ChatManag
           return;
         }
       } catch (error) {
-        console.error(
-          `❌ Error handling message from topic ${topic}:`,
-          error,
-          'Raw message:',
-          message.value.toString(),
+        getLogger().error(
+          { err: error, topic, raw: message.value.toString() },
+          '❌ Error handling Kafka message',
         );
       }
     },

--- a/src/v1/sockets/chat/kafka/consumer.ts
+++ b/src/v1/sockets/chat/kafka/consumer.ts
@@ -47,7 +47,7 @@ export async function startConsumer(namespace: Namespace, chatManager: ChatManag
       } catch (error) {
         getLogger().error(
           { err: error, topic, raw: message.value.toString() },
-          '❌ Error handling Kafka message',
+          'Error handling Kafka message',
         );
       }
     },

--- a/src/v1/sockets/chat/kafka/producer.ts
+++ b/src/v1/sockets/chat/kafka/producer.ts
@@ -1,9 +1,13 @@
 import { TOPICS } from './constants.js';
 import { producer } from '../../../../plugins/kafka.js';
 import { ResponseMessage } from '../chat.schema.js';
+import { getLogger } from '../../../../plugins/logger.js';
 
 export async function sendChat(chat: ResponseMessage) {
-  console.log(`Sending chat event to Kafka`);
+  getLogger().info(
+    { roomId: chat.roomId, messageId: chat.messageId },
+    'sending chat event to Kafka',
+  );
 
   await producer.send({
     topic: TOPICS.CHAT,

--- a/src/v1/sockets/utils/error-handler.ts
+++ b/src/v1/sockets/utils/error-handler.ts
@@ -1,8 +1,10 @@
+import { getLogger } from '../../../plugins/logger.js';
+
 export function socketErrorHandler<Args extends unknown[], Return>(
   handler: (...args: Args) => Return | Promise<Return>,
 ): (...args: Args) => void {
   const handleError = (err: unknown) => {
-    console.error('please handle me', err);
+    getLogger().error({ err }, 'socket handler error');
   };
 
   return (...args: Args): void => {

--- a/src/v1/sockets/utils/middleware.ts
+++ b/src/v1/sockets/utils/middleware.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, UnAuthorizedException } from '../../common/exceptions/core.error.js';
 import { Socket } from 'socket.io';
 import { verifyAccessToken } from './auth.js';
+import { getLogger } from '../../../plugins/logger.js';
 
 type NextFunction = (err?: Error) => void;
 
@@ -17,7 +18,7 @@ export async function socketMiddleware(socket: Socket, next: NextFunction) {
     socket.data.userId = Number(userId);
     next();
   } catch (e) {
-    console.error('Socket middleware error:', e);
+    getLogger().error({ err: e, sid: socket.id }, 'Socket middleware error');
     next(e as Error);
   }
 }


### PR DESCRIPTION
# feat: OpenTelemetry 추적 컨텍스트 연동 + Pino 로거 설정 개선

## 개요

* 서비스 전역 로깅을 **Pino**로 통일하고, **OpenTelemetry Span 컨텍스트(trace\_id 등)** 를 자동 주입했습니다.
* 에러 로깅은 **HTTP 중심 에러 직렬화기**로 표준화하고, **민감정보 자동 마스킹(redaction)** 을 적용했습니다.

## 변경 사항

* **로거 유틸 도입**

  * `getLogger()/setLogger()`로 전역 로거 교체 가능
  * `getPinoOptions()`에 레벨/레벨 포맷/민감정보 redaction/에러 직렬화 설정 집약
* **OTel 컨텍스트 자동 주입**

  * `pino mixin()`으로 활성 Span에서 `trace_id`(필요 시 `span_id`) 자동 부착

* **에러 직렬화기**
  * `HTTPError`, `ERR_NON_2XX_3XX_RESPONSE` 등 감지
  * `statusCode`, `http.method`, `http.url`, `stack` 포함
  * 
* **민감정보 자동 마스킹**

  * `authorization`, `cookie`, `*.password`, `*.token` 등 → `[Redacted]`
* **개발/운영 분기**

  * dev: `pino-pretty`로 가독성 향상(시간 변환/불필요 필드 ignore)
  * prod: JSON line 출력(수집/검색 최적화)
  * `LOG_LEVEL`/`NODE_ENV`로 제어
* **console.log 제거**

  * `console.log` → `logger.info|warn|error`로 치환
* **기타 리팩터링**

  * 채팅 룸/메시지 생성 경로 단순화(프라미스 직접 반환)

## 배경/의도

* 로그 포맷 혼재(JSON 한 줄 vs. 멀티라인 vs. console.log)를 해소하고 **관측성(Observability)** 을 강화
* Jaeger 트레이스와 로그를 `trace_id`로 손쉽게 상호 참조
* 운영 환경의 **보안/프라이버시 준수**(민감정보 마스킹)

## 테스트 방법

1. 임의 엔드포인트 호출 → `request completed` 로그에 `trace_id` 확인
2. 의도적으로 4xx/5xx 발생 → 에러 로그에 `statusCode`, `http.method`, `http.url`, `stack`(단일 라인) 확인
3. `Authorization`/`Cookie` 포함 요청 → 로그에 `[Redacted]` 처리 확인
4. dev/prod 모드 전환 → pretty/JSON 출력 확인